### PR TITLE
Add missing copier arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Make below requirements are met to use the copier template:
 ## Quick Start
 
 ```bash
-copier "https://github.com/pdm-project/copier-pdm.git" <project_name>
+copier copy --trust "https://github.com/pdm-project/copier-pdm.git" <project_name>
 ```
 
 Or even shorter:
 
 ```bash
-copier "gh:pdm-project/copier-pdm" <project_name>
+copier copy --trust "gh:pdm-project/copier-pdm" <project_name>
 ```
 
 See the [documentation](https://copier-pdm.fming.dev) for more details.


### PR DESCRIPTION
The command line flags have changed since the template was created.